### PR TITLE
Upgrade project to .NET 10

### DIFF
--- a/CSharpBenchLab.csproj
+++ b/CSharpBenchLab.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Bogus" Version="35.6.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Description
Upgrade the target framework of CSharpBenchLab from .NET 8 to .NET 10. This includes updating all relevant NuGet packages (such as Microsoft.EntityFrameworkCore) to their 10.x versions.

Motivation and Context
We want to keep the benchmarking project up-to-date with the latest release of .NET to take advantage of new language features, performance improvements, and to align with the newest framework standards.

Proposed Changes
Update <TargetFramework> in [CSharpBenchLab.csproj](vscode-webview://13fj8la954clpoepe08ncnbuogcjmndu7v00g7hn585e8uhm8kmf/CSharpBenchLab.csproj) from net8.0 to net10.0
Upgrade Microsoft.EntityFrameworkCore.InMemory to version 10.x (specifically 10.0.3)
Upgrade Microsoft.EntityFrameworkCore.Sqlite to version 10.x (specifically 10.0.3)
Verify the project builds successfully
Run all benchmarks to ensure there are no breaking changes or regressions
Impact on Existing Code
No breaking changes are expected for standard benchmark functionality.